### PR TITLE
Noticeably speed up dirty working tree check

### DIFF
--- a/functions/zgitinit
+++ b/functions/zgitinit
@@ -165,7 +165,7 @@ zgit_isindexclean() {
 
 zgit_isworktreeclean() {
 	zgit_isgit || return 1
-	if [ -z "$(git ls-files $zgit_info[dir] --modified)" ]; then
+	if [ -z "$(git ls-files $zgit_info[dir]:h --modified)" ]; then
 		return 0
 	else
 		return 1


### PR DESCRIPTION
This commit improves the prompt's responsiveness by using ls-files --modified instead of diff --quiet in zgit_isworktreeclean().
