### PR TITLE
Use --show-toplevel instead of --git-dir to get correct repo path

### DIFF
--- a/functions/zgitinit
+++ b/functions/zgitinit
@@ -25,7 +25,7 @@ zgit_precmd_hook() {
 zgit_info_update() {
 	zgit_info=()
 
-	local gitdir="$(git rev-parse --git-dir 2>/dev/null)"
+	local gitdir="$(git rev-parse --show-toplevel 2>/dev/null)"
 	if [ $? -ne 0 ] || [ -z "$gitdir" ]; then
 		return
 	fi
@@ -165,7 +165,7 @@ zgit_isindexclean() {
 
 zgit_isworktreeclean() {
 	zgit_isgit || return 1
-	if [ -z "$(git ls-files $zgit_info[dir]:h --modified)" ]; then
+	if [ -z "$(git ls-files $zgit_info[dir] --modified)" ]; then
 		return 0
 	else
 		return 1


### PR DESCRIPTION
This patch prevents an annoying error "fatal: '/home/user/repo/.git/modules' is outside repository " message anytime you cd into a submodule folder.
