### PR TITLE
Fix zgit_tracking_merge for branches containing a slash.

### DIFF
--- a/functions/zgitinit
+++ b/functions/zgitinit
@@ -143,7 +143,7 @@ zgit_tracking_merge() {
 	if [ -n "$remote" ]; then # tracking branch
 		local merge=$(git config branch.$branch.merge)
 		if [ $remote != "." ]; then
-			merge=$remote/$(basename $merge)
+			merge=$remote/${merge#refs/heads/}
 		fi
 		echo $merge
 		return 0


### PR DESCRIPTION
If the branch contains a slash (for example, a/b), zgit_tracking_merge returns an invalid branch such as origin/b instead of origin/a/b.